### PR TITLE
apiClientsStoreの作成

### DIFF
--- a/components/instances/mastodon/Compose.vue
+++ b/components/instances/mastodon/Compose.vue
@@ -17,8 +17,6 @@ const props = defineProps<{
   user: ILoginUser;
 }>();
 
-const { $repositories } = useNuxtApp();
-
 const message = ref<string>('');
 const submitting = ref<boolean>(false);
 
@@ -29,7 +27,7 @@ const submit = async () => {
 
   try {
     await (
-      await $repositories('mastodon').client(props.user)
+      await useApiClientsStore().get<'mastodon'>(props.user)
     ).v1.statuses.create({
       status: message.value,
       visibility: 'private',

--- a/components/instances/misskey/Compose.vue
+++ b/components/instances/misskey/Compose.vue
@@ -17,8 +17,6 @@ const props = defineProps<{
   user: ILoginUser;
 }>();
 
-const { $repositories } = useNuxtApp();
-
 const message = ref<string>('');
 const submitting = ref<boolean>(false);
 
@@ -28,7 +26,9 @@ const submit = async () => {
   submitting.value = true;
 
   try {
-    await $repositories('misskey').client(props.user).request('notes/create', {
+    await (
+      await useApiClientsStore().get<'misskey'>(props.user)
+    ).request('notes/create', {
       text: message.value,
       visibility: 'followers',
     });

--- a/factories/repositoryFactory.ts
+++ b/factories/repositoryFactory.ts
@@ -1,3 +1,4 @@
+import type { PromiseType } from '~/types/PromiseType';
 import type { IInstanceType } from '~/models/instanceType';
 import { mastodonRepository } from '~/repositories/instances/mastodon';
 import { misskeyRepository } from '~/repositories/instances/misskey';
@@ -12,6 +13,10 @@ export type IRepositories = {
     | IInstanceType
     | keyof typeof repositories]: (typeof repositories)[key];
 };
+
+export type IApiClients<T extends IInstanceType = IInstanceType> = PromiseType<
+  ReturnType<ReturnType<IRepositories[T]>['client']>
+>;
 
 export const repositoryFactory = {
   get: (name: keyof IRepositories) => repositories[name],

--- a/pages/callback/mastodon/[instance].vue
+++ b/pages/callback/mastodon/[instance].vue
@@ -33,7 +33,6 @@
 
 import type { ILoginUser } from '~/models/common/user';
 
-const { $repositories } = useNuxtApp();
 const $route = useRoute();
 
 const { add } = useLoginUsersStore();
@@ -64,7 +63,7 @@ const submit = async () => {
 
     try {
       const res = await (
-        await $repositories('mastodon').client(tempLoginUser)
+        await useApiClientsStore().get<'mastodon'>(tempLoginUser)
       ).v1.accounts.verifyCredentials();
 
       add({

--- a/stores/apiClientsStore.ts
+++ b/stores/apiClientsStore.ts
@@ -1,0 +1,24 @@
+import type { IApiClients } from '~/factories/repositoryFactory';
+import type { ILoginUser } from '~/models/common/user';
+
+export const useApiClientsStore = defineStore('apiClients', () => {
+  const apiClients = ref<{
+    [key: ILoginUser['id']]: IApiClients;
+  }>({});
+
+  const update = async (user: ILoginUser) => {
+    const { $repositories } = useNuxtApp();
+    const client = await $repositories(user.instance.type).client(user);
+    apiClients.value[user.id] = client;
+    return client;
+  };
+
+  const get = async <T extends ILoginUser['instance']['type']>(
+    user: ILoginUser,
+  ) => {
+    const client = apiClients.value[user.id];
+    return (client ?? (await update(user))) as IApiClients<T>;
+  };
+
+  return { get, update };
+});

--- a/types/PromiseType.d.ts
+++ b/types/PromiseType.d.ts
@@ -1,0 +1,3 @@
+export type PromiseType<T extends Promise<any> | any> = T extends Promise<infer P>
+  ? P
+  : T;


### PR DESCRIPTION
- apiClientをキャッシュしておくため、apiClientsStoreを作成