### PR TITLE
タイムラインの挙動を修正

### DIFF
--- a/components/common/Column/Timeline.vue
+++ b/components/common/Column/Timeline.vue
@@ -7,7 +7,11 @@
     >
       <template #header>
         <header class="flex flex-col bg-neutral px-3">
-          <div class="flex items-center h-12 py-2 gap-x-1">
+          <div
+            class="flex items-center h-12 py-2 gap-x-1"
+            :class="{ 'cursor-pointer': !isTop }"
+            @click="scrollup"
+          >
             <CommonPartsRoundedIcon :icon-url="user.iconUrl" class="w-8 h-8" />
             <p class="text-base font-semibold flex-auto">{{ timeline.name }}</p>
 
@@ -15,7 +19,7 @@
               type="button"
               class="btn btn-ghost btn-square btn-sm w-fit"
               tabindex="-1"
-              @click="toggleDetail"
+              @click.stop="toggleDetail"
             >
               <span class="material-symbols-outlined text-lg">
                 {{ isDetailExpanded ? 'expand_less' : 'expand_more' }}
@@ -29,7 +33,7 @@
         </header>
       </template>
 
-      <div class="divide-y divide-dashed divide-neutral">
+      <div ref="body" class="divide-y divide-dashed divide-neutral">
         <template v-for="item in items" :key="item.id">
           <!-- コンポーネントにnowは不要だが、つけることで相対時間の更新ができる -->
           <component
@@ -79,6 +83,11 @@ const now = ref<number>(Date.now());
 
 const toggleDetail = () => {
   isDetailExpanded.value = !isDetailExpanded.value;
+};
+
+const body = ref<HTMLElement>();
+const scrollup = () => {
+  body.value?.scrollIntoView({ behavior: 'smooth' });
 };
 
 // ロード

--- a/components/common/Column/Timeline.vue
+++ b/components/common/Column/Timeline.vue
@@ -106,12 +106,14 @@ const loadPast = async () => {
   isLoading.value = false;
 };
 
-useWebSocket(props.timeline, (message: IMessage) => {
-  items.value.reverse().push(message);
-  items.value.reverse();
-  if (items.value.length > 40 && isTop.value) {
-    items.value.length = 40;
-  }
+onMounted(async () => {
+  await useWebSocket(props.timeline, (message: IMessage) => {
+    items.value.reverse().push(message);
+    items.value.reverse();
+    if (items.value.length > 40 && isTop.value) {
+      items.value.length = 40;
+    }
+  });
 });
 
 setInterval(() => {

--- a/components/common/Column/Timeline.vue
+++ b/components/common/Column/Timeline.vue
@@ -2,7 +2,7 @@
   <section>
     <CommonContainer
       class="h-full w-[330px] bg-base-100"
-      @top="(value) => (isTop = value)"
+      @top="atTop"
       @bottom="loadPast"
     >
       <template #header>
@@ -86,6 +86,17 @@ const isLoadable = ref(true);
 const isLoading = ref(false);
 const isTop = ref(true);
 
+const limitItemCount = () => {
+  if (items.value.length > 40 && isTop.value) {
+    items.value.length = 40;
+  }
+};
+
+const atTop = (value: boolean) => {
+  isTop.value = value;
+  limitItemCount();
+};
+
 const loadPast = async () => {
   if (isLoading.value || !isLoadable.value) {
     return;
@@ -110,9 +121,7 @@ onMounted(async () => {
   await useWebSocket(props.timeline, (message: IMessage) => {
     items.value.reverse().push(message);
     items.value.reverse();
-    if (items.value.length > 40 && isTop.value) {
-      items.value.length = 40;
-    }
+    limitItemCount();
   });
 });
 

--- a/components/common/Container.vue
+++ b/components/common/Container.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="common-container flex flex-col">
+  <div ref="container" class="common-container flex flex-col">
     <div class="common-container-header">
       <slot name="header" class="common-container-header"></slot>
     </div>
@@ -26,19 +26,31 @@ const emits = defineEmits<{
   (e: 'bottom'): void;
 }>();
 
+const container = ref<HTMLElement>();
 const topElement = ref<HTMLElement>();
-const topObserver = new IntersectionObserver((entries) => {
-  emits('top', entries[0]?.isIntersecting ?? false);
-});
-
 const bottomElement = ref<HTMLElement>();
-const bottomObserver = new IntersectionObserver((entries) => {
-  if (entries[0]?.isIntersecting) {
-    emits('bottom');
-  }
-});
 
 onMounted(() => {
+  const topObserver = new IntersectionObserver(
+    (entries) => {
+      emits('top', entries[0]?.isIntersecting ?? false);
+    },
+    {
+      root: container.value!,
+    },
+  );
+
+  const bottomObserver = new IntersectionObserver(
+    (entries) => {
+      if (entries[0]?.isIntersecting) {
+        emits('bottom');
+      }
+    },
+    {
+      root: container.value!,
+    },
+  );
+
   topObserver.observe(topElement.value!);
   bottomObserver.observe(bottomElement.value!);
 });


### PR DESCRIPTION
- `useWebSocket` の使い方を修正
- intersection observerのrootを、各columnになるように設定
  - もともとはviewportだったので、画面外のカラムではarrayのリセットが行われていなかった
- 一番上に戻った際にすぐに個数制限をかけるように修正
- ヘッダをクリックして一番上に戻れるように