### PR TITLE
ブラウザによる差異をなくす

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -15,8 +15,3 @@
   font-size: inherit;
   line-height: inherit;
 }
-
-/* bug? */
-.dropdown-end .dropdown-content {
-  right: initial;
-}

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -11,6 +11,11 @@
   border-radius: 4px;
 }
 
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--p)) transparent;
+}
+
 .textarea {
   font-size: inherit;
   line-height: inherit;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,4 +3,14 @@ module.exports = {
   daisyui: {
     themes: ['dark'],
   },
+  theme: {
+    extend: {
+      width: {
+        screen: ['100vw', '100dvw'],
+      },
+      height: {
+        screen: ['100vh', '100dvh'],
+      },
+    },
+  },
 };


### PR DESCRIPTION
- 不要になったCSSを削除
- FireFoxでのスクロールバーのデザインを調整
- iOSでの全画面表示のため、dvw, dvh をサポート

Safariにおいてスクロール位置が保持されないのは、解決が難しそうなので対応しない