### PR TITLE
クライアントの作成は1回のみ行うようにapiClientsStoreを修正

### DIFF
--- a/factories/repositoryFactory.ts
+++ b/factories/repositoryFactory.ts
@@ -1,4 +1,3 @@
-import type { PromiseType } from '~/types/PromiseType';
 import type { IInstanceType } from '~/models/instanceType';
 import { mastodonRepository } from '~/repositories/instances/mastodon';
 import { misskeyRepository } from '~/repositories/instances/misskey';
@@ -14,8 +13,8 @@ export type IRepositories = {
     | keyof typeof repositories]: (typeof repositories)[key];
 };
 
-export type IApiClients<T extends IInstanceType = IInstanceType> = PromiseType<
-  ReturnType<ReturnType<IRepositories[T]>['client']>
+export type IApiClients<T extends IInstanceType = IInstanceType> = ReturnType<
+  ReturnType<IRepositories[T]>['client']
 >;
 
 export const repositoryFactory = {

--- a/repositories/instances/mastodon/index.ts
+++ b/repositories/instances/mastodon/index.ts
@@ -33,12 +33,12 @@ export const mastodonRepository = () => ({
     params?: { sinceId?: string; untilId?: string },
   ) => {
     return (
-      await (
-        await useApiClientsStore().get<'mastodon'>(user)
-      ).api.v1.timelines.home.list({
-        maxId: params?.untilId,
-        minId: params?.sinceId,
-      })
+      await useApiClientsStore()
+        .get<'mastodon'>(user)
+        .api.v1.timelines.home.list({
+          maxId: params?.untilId,
+          minId: params?.sinceId,
+        })
     ).map(mastodonConverter.statusToMessage);
   },
   getLocalTimeline: async (
@@ -46,13 +46,13 @@ export const mastodonRepository = () => ({
     params?: { sinceId?: string; untilId?: string },
   ) => {
     return (
-      await (
-        await useApiClientsStore().get<'mastodon'>(user)
-      ).api.v1.timelines.public.list({
-        local: true,
-        maxId: params?.untilId,
-        minId: params?.sinceId,
-      })
+      await useApiClientsStore()
+        .get<'mastodon'>(user)
+        .api.v1.timelines.public.list({
+          local: true,
+          maxId: params?.untilId,
+          minId: params?.sinceId,
+        })
     ).map(mastodonConverter.statusToMessage);
   },
   getFedarationTimeline: async (
@@ -60,12 +60,12 @@ export const mastodonRepository = () => ({
     params?: { sinceId?: string; untilId?: string },
   ) => {
     return (
-      await (
-        await useApiClientsStore().get<'mastodon'>(user)
-      ).api.v1.timelines.public.list({
-        maxId: params?.untilId,
-        minId: params?.sinceId,
-      })
+      await useApiClientsStore()
+        .get<'mastodon'>(user)
+        .api.v1.timelines.public.list({
+          maxId: params?.untilId,
+          minId: params?.sinceId,
+        })
     ).map(mastodonConverter.statusToMessage);
   },
   getListTimeline: async (
@@ -74,10 +74,9 @@ export const mastodonRepository = () => ({
     params?: { sinceId?: string; untilId?: string },
   ) => {
     return (
-      await (
-        await useApiClientsStore().get<'mastodon'>(user)
-      ).api.v1.timelines.list
-        .$select(listId)
+      await useApiClientsStore()
+        .get<'mastodon'>(user)
+        .api.v1.timelines.list.$select(listId)
         .list({
           maxId: params?.untilId,
           minId: params?.sinceId,
@@ -90,8 +89,9 @@ export const mastodonRepository = () => ({
     params?: { sinceId?: string; untilId?: string },
   ) => {
     return (
-      await (await useApiClientsStore().get<'mastodon'>(user)).api.v1.accounts
-        .$select(userId)
+      await useApiClientsStore()
+        .get<'mastodon'>(user)
+        .api.v1.accounts.$select(userId)
         .statuses.list({
           maxId: params?.untilId,
           minId: params?.sinceId,
@@ -102,9 +102,9 @@ export const mastodonRepository = () => ({
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    for await (const entry of (
-      await useApiClientsStore().get<'mastodon'>(user)
-    ).ws.user.subscribe()) {
+    for await (const entry of useApiClientsStore()
+      .get<'mastodon'>(user)
+      .ws.user.subscribe()) {
       if (entry.event === 'update') {
         callback(mastodonConverter.statusToMessage(entry.payload));
       }
@@ -114,9 +114,9 @@ export const mastodonRepository = () => ({
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    for await (const entry of (
-      await useApiClientsStore().get<'mastodon'>(user)
-    ).ws.public.local.subscribe()) {
+    for await (const entry of useApiClientsStore()
+      .get<'mastodon'>(user)
+      .ws.public.local.subscribe()) {
       if (entry.event === 'update') {
         callback(mastodonConverter.statusToMessage(entry.payload));
       }
@@ -126,9 +126,9 @@ export const mastodonRepository = () => ({
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    for await (const entry of (
-      await useApiClientsStore().get<'mastodon'>(user)
-    ).ws.public.remote.subscribe()) {
+    for await (const entry of useApiClientsStore()
+      .get<'mastodon'>(user)
+      .ws.public.remote.subscribe()) {
       if (entry.event === 'update') {
         callback(mastodonConverter.statusToMessage(entry.payload));
       }
@@ -139,9 +139,9 @@ export const mastodonRepository = () => ({
     listId: string,
     callback: (message: IMessage) => void,
   ) => {
-    for await (const entry of (
-      await useApiClientsStore().get<'mastodon'>(user)
-    ).ws.list.subscribe({ list: listId })) {
+    for await (const entry of useApiClientsStore()
+      .get<'mastodon'>(user)
+      .ws.list.subscribe({ list: listId })) {
       if (entry.event === 'update') {
         callback(mastodonConverter.statusToMessage(entry.payload));
       }

--- a/repositories/instances/misskey/index.ts
+++ b/repositories/instances/misskey/index.ts
@@ -58,31 +58,30 @@ export const misskeyRepository = () => ({
   getHomeTimeline: async (
     user: ILoginUser,
     params?: { sinceId?: string; untilId?: string },
-  ) => {
-    return (
-      await (
-        await useApiClientsStore().get<'misskey'>(user)
-      ).api.request('notes/timeline', params)
-    ).map((note) => misskeyConverter.noteToMessage(note, user));
-  },
+  ) =>
+    (
+      await useApiClientsStore()
+        .get<'misskey'>(user)
+        .api.request('notes/timeline', params)
+    ).map((note) => misskeyConverter.noteToMessage(note, user)),
   getLocalTimeline: async (
     user: ILoginUser,
     params?: { sinceId?: string; untilId?: string },
   ) => {
-    return (
-      await (
-        await useApiClientsStore().get<'misskey'>(user)
-      ).api.request('notes/local-timeline', params)
+    (
+      await useApiClientsStore()
+        .get<'misskey'>(user)
+        .api.request('notes/local-timeline', params)
     ).map((note) => misskeyConverter.noteToMessage(note, user));
   },
   getFedarationTimeline: async (
     user: ILoginUser,
     params?: { sinceId?: string; untilId?: string },
   ) => {
-    return (
-      await (
-        await useApiClientsStore().get<'misskey'>(user)
-      ).api.request('notes/global-timeline', params)
+    (
+      await useApiClientsStore()
+        .get<'misskey'>(user)
+        .api.request('notes/global-timeline', params)
     ).map((note) => misskeyConverter.noteToMessage(note, user));
   },
   getListTimeline: async (
@@ -90,14 +89,14 @@ export const misskeyRepository = () => ({
     listId: string,
     params?: { sinceId?: string; untilId?: string },
   ) => {
-    return (
-      await (
-        await useApiClientsStore().get<'misskey'>(user)
-      ).api.request('notes/user-list-timeline', {
-        listId,
-        sinceId: params?.sinceId,
-        untilId: params?.untilId,
-      })
+    (
+      await useApiClientsStore()
+        .get<'misskey'>(user)
+        .api.request('notes/user-list-timeline', {
+          listId,
+          sinceId: params?.sinceId,
+          untilId: params?.untilId,
+        })
     ).map((note) => misskeyConverter.noteToMessage(note, user));
   },
   getUserTimeline: async (
@@ -105,47 +104,50 @@ export const misskeyRepository = () => ({
     userId: string,
     params?: { sinceId?: string; untilId?: string },
   ) => {
-    return (
-      await (
-        await useApiClientsStore().get<'misskey'>(user)
-      ).api.request('users/notes', {
-        userId,
-        sinceId: params?.sinceId,
-        untilId: params?.untilId,
-      })
+    (
+      await useApiClientsStore()
+        .get<'misskey'>(user)
+        .api.request('users/notes', {
+          userId,
+          sinceId: params?.sinceId,
+          untilId: params?.untilId,
+        })
     ).map((note) => misskeyConverter.noteToMessage(note, user));
   },
-  setHomeStreaming: async (
+  setHomeStreaming: (
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    (await useApiClientsStore().get<'misskey'>(user)).ws
-      .useChannel('homeTimeline')
+    useApiClientsStore()
+      .get<'misskey'>(user)
+      .ws.useChannel('homeTimeline')
       .on('note', (note) => {
         callback(misskeyConverter.noteToMessage(note, user));
       });
   },
-  setLocalStreaming: async (
+  setLocalStreaming: (
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    (await useApiClientsStore().get<'misskey'>(user)).ws
-      .useChannel('localTimeline')
+    useApiClientsStore()
+      .get<'misskey'>(user)
+      .ws.useChannel('localTimeline')
       .on('note', (note) => {
         callback(misskeyConverter.noteToMessage(note, user));
       });
   },
-  setFederationStreaming: async (
+  setFederationStreaming: (
     user: ILoginUser,
     callback: (message: IMessage) => void,
   ) => {
-    (await useApiClientsStore().get<'misskey'>(user)).ws
-      .useChannel('globalTimeline')
+    useApiClientsStore()
+      .get<'misskey'>(user)
+      .ws.useChannel('globalTimeline')
       .on('note', (note) => {
         callback(misskeyConverter.noteToMessage(note, user));
       });
   },
-  setListStreaming: async (
+  setListStreaming: (
     _user: ILoginUser,
     _listId: string,
     _callback: (message: IMessage) => void,

--- a/stores/apiClientsStore.ts
+++ b/stores/apiClientsStore.ts
@@ -6,18 +6,16 @@ export const useApiClientsStore = defineStore('apiClients', () => {
     [key: ILoginUser['id']]: IApiClients;
   }>({});
 
-  const update = async (user: ILoginUser) => {
+  const update = (user: ILoginUser) => {
     const { $repositories } = useNuxtApp();
-    const client = await $repositories(user.instance.type).client(user);
+    const client = $repositories(user.instance.type).client(user);
     apiClients.value[user.id] = client;
     return client;
   };
 
-  const get = async <T extends ILoginUser['instance']['type']>(
-    user: ILoginUser,
-  ) => {
+  const get = <T extends ILoginUser['instance']['type']>(user: ILoginUser) => {
     const client = apiClients.value[user.id];
-    return (client ?? (await update(user))) as IApiClients<T>;
+    return (client ?? update(user)) as IApiClients<T>;
   };
 
   return { get, update };


### PR DESCRIPTION
awaitしていたためクライアントが複数回作成されてしまい、WebSocketを複数個持つことになっていたので修正

### メモ
- awaitすると、その間に別のリクエストがあればリクエストが飛んでしまう
  - そのため、Promiseはそのままキャッシュする方針にするべき