### PR TITLE
画像・動画・音声の表示実装

### DIFF
--- a/components/common/Column/Item/Media.vue
+++ b/components/common/Column/Item/Media.vue
@@ -1,0 +1,76 @@
+<template>
+  <div
+    v-if="isVisible"
+    class="relative cursor-zoom-in overflow-hidden"
+    @click="$emit('click')"
+  >
+    <video
+      v-if="media.type === 'video'"
+      class="w-full h-full object-cover rounded"
+      :poster="media.thumbnailUrl"
+      preload="none"
+      controls
+      controlslist="nodownload"
+      muted
+    >
+      <source :src="media.url" :type="media.detailedType" />
+    </video>
+
+    <img
+      v-if="media.type === 'image'"
+      :src="media.thumbnailUrl"
+      class="w-full h-full object-cover rounded"
+      draggable="false"
+    />
+
+    <div
+      v-if="media.type === 'audio'"
+      class="w-full h-full flex items-center rounded bg-neutral-focus"
+    >
+      <audio
+        :src="media.thumbnailUrl"
+        class="w-full"
+        controls
+        controlslist="nodownload"
+      />
+    </div>
+
+    <button
+      v-if="media.sensitive"
+      type="button"
+      class="btn btn-xs btn-square btn-neutral absolute right-1 top-1"
+      @click.stop="isVisible = false"
+    >
+      <span class="material-symbols-outlined text-base">visibility_off</span>
+    </button>
+  </div>
+
+  <button
+    v-else
+    type="button"
+    class="w-full h-full rounded bg-neutral"
+    @click="isVisible = true"
+  >
+    <div class="flex justify-center items-center">
+      <span class="">sensitive</span>
+    </div>
+  </button>
+</template>
+
+<script setup lang="ts">
+import type { IMedia } from '~/models/common/media';
+
+const props = defineProps<{
+  media: IMedia;
+}>();
+
+defineEmits<{
+  (e: 'click'): void;
+}>();
+
+const isVisible = ref(true);
+
+onMounted(() => {
+  isVisible.value = !props.media.sensitive;
+});
+</script>

--- a/components/common/Column/Item/Media.vue
+++ b/components/common/Column/Item/Media.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="isVisible"
-    class="relative cursor-zoom-in overflow-hidden"
+    class="w-full h-full relative cursor-zoom-in overflow-hidden"
     @click="$emit('click')"
   >
     <video
@@ -48,12 +48,10 @@
   <button
     v-else
     type="button"
-    class="w-full h-full rounded bg-neutral"
+    class="w-full h-full rounded flex justify-center items-center bg-neutral"
     @click="isVisible = true"
   >
-    <div class="flex justify-center items-center">
-      <span class="">sensitive</span>
-    </div>
+    <span class="">sensitive</span>
   </button>
 </template>
 

--- a/components/common/Column/Item/Media.vue
+++ b/components/common/Column/Item/Media.vue
@@ -32,6 +32,7 @@
         class="w-full"
         controls
         controlslist="nodownload"
+        @click.stop
       />
     </div>
 

--- a/components/common/Column/Item/Media.vue
+++ b/components/common/Column/Item/Media.vue
@@ -49,7 +49,7 @@
   <button
     v-else
     type="button"
-    class="w-full h-full rounded flex justify-center items-center bg-neutral"
+    class="w-full h-full rounded bg-neutral"
     @click="isVisible = true"
   >
     <span class="">sensitive</span>

--- a/components/common/Column/Item/MediaList.vue
+++ b/components/common/Column/Item/MediaList.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="mediaList.length" class="relative">
-    <div class="grid gap-1" :class="gridClass">
+    <div class="grid gap-1 h-full w-full" :class="gridClass">
       <template
         v-for="(media, index) in mediaList.slice(0, displayCount)"
         :key="media"

--- a/components/common/Column/Item/MediaList.vue
+++ b/components/common/Column/Item/MediaList.vue
@@ -1,0 +1,33 @@
+<template>
+  <div v-if="mediaList.length" class="relative">
+    <div class="grid gap-1 aspect-video" :class="gridClass">
+      <template v-for="media in mediaList.slice(0, 4)" :key="media">
+        <CommonColumnItemMedia
+          :media="media"
+          :class="{ 'first:row-span-2': mediaList.length === 3 }"
+        />
+      </template>
+    </div>
+    <span
+      v-if="mediaList.length > 4"
+      class="badge badge-primary absolute -bottom-2.5 right-0"
+    >
+      +{{ mediaList.length - 4 }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { IMedia } from '~/models/common/media';
+
+const props = defineProps<{
+  mediaList: IMedia[];
+}>();
+
+const gridClass =
+  props.mediaList.length === 1
+    ? 'grid-cols-1 grid-rows-1'
+    : props.mediaList.length === 2
+    ? 'grid-cols-2 grid-rows-1'
+    : 'grid-cols-2 grid-rows-2';
+</script>

--- a/components/common/Column/Item/MediaList.vue
+++ b/components/common/Column/Item/MediaList.vue
@@ -1,8 +1,15 @@
 <template>
   <div v-if="mediaList.length" class="relative">
     <div class="grid gap-1" :class="gridClass">
-      <template v-for="media in mediaList.slice(0, displayCount)" :key="media">
-        <CommonColumnItemMedia :media="media" :class="itemClass" />
+      <template
+        v-for="(media, index) in mediaList.slice(0, displayCount)"
+        :key="media"
+      >
+        <CommonColumnItemMedia
+          :media="media"
+          :class="itemClass"
+          @click="openModal(index)"
+        />
       </template>
     </div>
     <span
@@ -42,5 +49,18 @@ const itemClass = computed(() =>
 
 const expand = () => {
   displayCount.value = props.mediaList.length;
+};
+
+const openModal = (index: number) => {
+  modalsStore().add(
+    'media',
+    resolveComponent('CommonModalsMedia'),
+    { mediaList: props.mediaList, initial: index },
+    {
+      hasHeader: false,
+      width: 'fit-content',
+      maxHeight: '95%',
+    },
+  );
 };
 </script>

--- a/components/common/Column/Item/MediaList.vue
+++ b/components/common/Column/Item/MediaList.vue
@@ -34,7 +34,7 @@ const gridClass = computed(() =>
 
 const itemClass = computed(() =>
   props.mediaList.length === 3
-    ? 'first:row-span-2'
+    ? 'first:row-span-2 aspect-video first:aspect-auto'
     : props.mediaList.length > 3
     ? 'aspect-video'
     : '',

--- a/components/common/Column/Item/MediaList.vue
+++ b/components/common/Column/Item/MediaList.vue
@@ -1,18 +1,16 @@
 <template>
   <div v-if="mediaList.length" class="relative">
-    <div class="grid gap-1 aspect-video" :class="gridClass">
-      <template v-for="media in mediaList.slice(0, 4)" :key="media">
-        <CommonColumnItemMedia
-          :media="media"
-          :class="{ 'first:row-span-2': mediaList.length === 3 }"
-        />
+    <div class="grid gap-1" :class="gridClass">
+      <template v-for="media in mediaList.slice(0, displayCount)" :key="media">
+        <CommonColumnItemMedia :media="media" :class="itemClass" />
       </template>
     </div>
     <span
-      v-if="mediaList.length > 4"
-      class="badge badge-primary absolute -bottom-2.5 right-0"
+      v-if="mediaList.length > displayCount"
+      class="badge badge-primary cursor-pointer absolute -bottom-2.5 right-0"
+      @click="expand"
     >
-      +{{ mediaList.length - 4 }}
+      +{{ mediaList.length - displayCount }}
     </span>
   </div>
 </template>
@@ -24,10 +22,25 @@ const props = defineProps<{
   mediaList: IMedia[];
 }>();
 
-const gridClass =
+const displayCount = ref(4);
+
+const gridClass = computed(() =>
   props.mediaList.length === 1
-    ? 'grid-cols-1 grid-rows-1'
-    : props.mediaList.length === 2
-    ? 'grid-cols-2 grid-rows-1'
-    : 'grid-cols-2 grid-rows-2';
+    ? 'grid-cols-1 grid-rows-1 aspect-video'
+    : props.mediaList.length < 4
+    ? 'grid-cols-2 aspect-video'
+    : 'grid-cols-2',
+);
+
+const itemClass = computed(() =>
+  props.mediaList.length === 3
+    ? 'first:row-span-2'
+    : props.mediaList.length > 3
+    ? 'aspect-video'
+    : '',
+);
+
+const expand = () => {
+  displayCount.value = props.mediaList.length;
+};
 </script>

--- a/components/common/Modals/Media.vue
+++ b/components/common/Modals/Media.vue
@@ -1,0 +1,74 @@
+<template>
+  <div
+    ref="modalMedia"
+    class="h-full w-fit flex items-center outline-none relative"
+    tabindex="0"
+    @keydown.right="goNext"
+    @keydown.left="goPrev"
+  >
+    <video
+      v-if="current.type === 'video'"
+      :src="current.url"
+      class="max-h-full max-w-full"
+      controls
+      controlslist="nodownload"
+      autoplay
+    >
+      <source :src="current.url" :type="current.detailedType" />
+    </video>
+    <img
+      v-if="current.type === 'image'"
+      :src="current.url"
+      class="max-h-full max-w-full"
+      draggable="false"
+    />
+    <audio
+      v-if="current.type === 'audio'"
+      :src="current.url"
+      class="max-h-full max-w-full"
+      controls
+      controlslist="nodownload"
+      autoplay
+    />
+
+    <div
+      v-if="mediaList.length > 1"
+      class="btm-nav btm-nav-xs justify-center opacity-20 hover:opacity-75 transition-opacity absolute"
+    >
+      <button class="flex-none" @click="goPrev">
+        <span class="material-symbols-outlined">arrow_back_ios_new</span>
+      </button>
+      <div class="w-24 flex-none">{{ index + 1 }} / {{ mediaList.length }}</div>
+      <button class="flex-none" @click="goNext">
+        <span class="material-symbols-outlined">arrow_forward_ios</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { IMedia } from '~/models/common/media';
+
+const props = defineProps<{
+  mediaList: IMedia[];
+  initial: number;
+}>();
+
+const modalMedia = ref<HTMLElement>();
+
+const index = shallowRef(0);
+const current = computed(() => props.mediaList[index.value]);
+
+const goNext = () => {
+  index.value = (index.value + 1) % props.mediaList.length;
+};
+const goPrev = () => {
+  index.value =
+    (props.mediaList.length + index.value - 1) % props.mediaList.length;
+};
+
+onMounted(() => {
+  index.value = props.initial;
+  modalMedia.value?.focus();
+});
+</script>

--- a/components/common/Modals/Media.vue
+++ b/components/common/Modals/Media.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="modalMedia"
-    class="h-full w-fit flex items-center outline-none relative"
+    class="h-full w-fit flex flex-col justify-center outline-none relative"
     tabindex="0"
     @keydown.right="goNext"
     @keydown.left="goPrev"

--- a/components/common/Modals/index.vue
+++ b/components/common/Modals/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="modalRef"
-    class="modal z-40"
+    class="modal z-40 outline-none"
     :class="{ 'modal-open': isShown }"
     tabindex="0"
     @click="close()"
@@ -9,16 +9,19 @@
   >
     <div
       v-if="current"
-      class="modal-box border border-secondary p-[1rem]"
+      class="modal-box border border-secondary h-full w-full p-[1rem]"
       :style="{
-        width: current.displayOptions?.width ?? '70%',
-        height: current.displayOptions?.height ?? '90%',
-        'max-width': current.displayOptions?.maxWidth ?? '1024px',
-        'max-height': current.displayOptions?.maxHeight ?? '1024px',
+        width: current.displayOptions?.width,
+        height: current.displayOptions?.height,
+        'max-width': current.displayOptions?.maxWidth ?? '90%',
+        'max-height': current.displayOptions?.maxHeight ?? '90%',
       }"
       @click.stop
     >
-      <div class="flex items-center gap-x-2">
+      <div
+        v-if="current.displayOptions?.hasHeader !== false"
+        class="flex items-center gap-x-2"
+      >
         <button
           type="button"
           class="btn btn-sm btn-square btn-ghost"
@@ -29,13 +32,11 @@
           </span>
         </button>
         <div class="text-xl font-bold">{{ current.name }}</div>
+
+        <div class="divider my-2"></div>
       </div>
 
-      <div class="divider my-2"></div>
-
-      <div class="">
-        <component :is="current.component" v-bind="current.props" />
-      </div>
+      <component :is="current.component" v-bind="current.props" />
     </div>
   </div>
 </template>
@@ -73,9 +74,3 @@ watch(
   },
 );
 </script>
-
-<style scoped>
-.modal:focus {
-  outline: none;
-}
-</style>

--- a/components/instances/mastodon/ColumnItem.vue
+++ b/components/instances/mastodon/ColumnItem.vue
@@ -21,6 +21,8 @@
 
     <p class="w-full break-words text-sm" v-html="sanitizedHTML"></p>
 
+    <CommonColumnItemMediaList :media-list="mediaList" />
+
     <template #footer>
       <div class="flex gap-x-1 mt-1">
         <span></span>
@@ -42,6 +44,7 @@
 </template>
 
 <script setup lang="ts">
+import type { IMedia } from '~/models/common/media';
 import type { IMastodonMessage } from '~/models/instances/mastodon/message';
 
 const props = defineProps<{
@@ -55,5 +58,17 @@ const actualItem = computed(() =>
 );
 const sanitizedHTML = computed(() =>
   sanitizeHTML(actualItem.value.body.content),
+);
+
+const mediaList = computed<IMedia[]>(() =>
+  actualItem.value.body.mediaAttachments
+    .filter((media) => media.type !== 'unknown')
+    .map<IMedia>((file) => ({
+      type: file.type === 'gifv' ? 'image' : (file.type as IMedia['type']),
+      detailedType: file.type,
+      thumbnailUrl: file.previewUrl,
+      url: file.url ?? file.previewUrl,
+      sensitive: actualItem.value.body.sensitive,
+    })),
 );
 </script>

--- a/components/instances/misskey/ColumnItem.vue
+++ b/components/instances/misskey/ColumnItem.vue
@@ -23,6 +23,8 @@
       {{ actualItem.body.text }}
     </p>
 
+    <CommonColumnItemMediaList :media-list="mediaList" />
+
     <template #footer>
       <div class="flex gap-x-1 mt-1">
         <span></span>
@@ -44,6 +46,7 @@
 </template>
 
 <script setup lang="ts">
+import { mediaTypes, type IMedia } from '~/models/common/media';
 import type { IMisskeyMessage } from '~/models/instances/misskey/message';
 
 const props = defineProps<{
@@ -55,5 +58,19 @@ const actualItem = computed(() =>
   props.item.body.renote
     ? misskeyConverter.noteToMessage(props.item.body.renote, props.item.via)
     : props.item,
+);
+
+const mediaList = computed<IMedia[]>(() =>
+  actualItem.value.body.files
+    .filter((file) =>
+      mediaTypes.some((mediaType) => file.type.startsWith(mediaType)),
+    )
+    .map<IMedia>((file) => ({
+      type: mediaTypes.find((mediaType) => file.type.startsWith(mediaType))!,
+      detailedType: file.type,
+      thumbnailUrl: file.thumbnailUrl ?? file.url,
+      url: file.url,
+      sensitive: file.isSensitive,
+    })),
 );
 </script>

--- a/models/common/media.ts
+++ b/models/common/media.ts
@@ -1,0 +1,9 @@
+export const mediaTypes = ['video', 'image', 'audio'] as const;
+
+export type IMedia = {
+  type: (typeof mediaTypes)[number];
+  detailedType: string;
+  thumbnailUrl: string;
+  url: string;
+  sensitive: boolean;
+};

--- a/stores/modalsStore.ts
+++ b/stores/modalsStore.ts
@@ -6,8 +6,9 @@ type IModal = {
   component: ReturnType<typeof resolveComponent>;
   props: {};
   displayOptions?: {
-    width?: `${number}px` | `${number}%`;
-    height?: `${number}px` | `${number}%`;
+    hasHeader?: boolean; // false指定のときのみ非表示
+    width?: `${number}px` | `${number}%` | 'fit-content';
+    height?: `${number}px` | `${number}%` | 'fit-content';
     maxWidth?: `${number}px` | `${number}%`;
     maxHeight?: `${number}px` | `${number}%`;
   };


### PR DESCRIPTION
タイムライン上に画像・動画・音声を表示、拡大表示ができるようにしました

以下は対応が大変なため、今後対応を検討する
- 3つの場合で2,3個目の高さが同一にならない
- 画像が横長の場合でも、モーダルが縦に全画面になる