### PR TITLE
datasourcesStoreを削除

### DIFF
--- a/components/common/Column/Timeline.vue
+++ b/components/common/Column/Timeline.vue
@@ -71,9 +71,7 @@ const columnItemComponents = {
   misskey: resolveComponent('MisskeyColumnItem'),
 };
 
-const { datasources } = storeToRefs(useDatasourcesStore());
-datasources.value[props.timeline.id] = [];
-const items = computed(() => datasources.value[props.timeline.id]);
+const items = ref<IMessage[]>([]);
 
 const { loginUsers } = storeToRefs(useLoginUsersStore());
 const user = computed(() => loginUsers.value[props.timeline.query.user]);

--- a/stores/datasourcesStore.ts
+++ b/stores/datasourcesStore.ts
@@ -1,8 +1,0 @@
-import type { ITimeline } from '~/models/common/timeline';
-import type { IMessage } from '~/models/common/message';
-
-export const useDatasourcesStore = defineStore('datasources', () => {
-  const datasources = ref<{ [key: ITimeline['id']]: IMessage[] }>({});
-
-  return { datasources };
-});


### PR DESCRIPTION
現状ではStoreにするメリットがないので削除

全体を1つのdatasourcesを持つ、などの用途ができればまた作成する