### PR TITLE
timelineにoverflow-x-hiddenを追加

### DIFF
--- a/components/common/Column/Timeline.vue
+++ b/components/common/Column/Timeline.vue
@@ -36,7 +36,10 @@
         </header>
       </template>
 
-      <div ref="body" class="divide-y divide-dashed divide-neutral">
+      <div
+        ref="body"
+        class="divide-y divide-dashed divide-neutral overflow-x-hidden"
+      >
         <template v-for="item in items.slice().reverse()" :key="item.id">
           <!-- コンポーネントにnowは不要だが、つけることで相対時間の更新ができる -->
           <component


### PR DESCRIPTION
Misskeyのカラムのみ横スクロールができる状態になっていた

Misskeyのリアクションのtooltipがカラムの外にはみ出ていたのが原因
overflow-x-hiddenを適用してスクロールができないようにした

TODO: tooltipを全体にオーバーレイする形に変えたい