### PR TITLE
Misskeyリアクションのhover表示を調整

### DIFF
--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -3,8 +3,7 @@
     <li
       v-for="reaction in shownReactions"
       :key="reaction.key"
-      class="tooltip tooltip-bottom"
-      :data-tip="reaction.key.replace('@.', '')"
+      class="dropdown dropdown-center dropdown-hover"
     >
       <button
         class="btn btn-xs no-animation py-0.5 gap-x-1"
@@ -19,6 +18,11 @@
         />
         {{ reaction.count }}
       </button>
+      <span
+        class="dropdown-content pointer-events-none card p-1 bg-neutral text-sm z-10"
+      >
+        {{ reaction.key.replace('@.', '') }}
+      </span>
     </li>
     <li v-if="reactions.length > REACTIONS_LIMIT && !isShowAll">
       <button
@@ -56,3 +60,12 @@ const showMore = () => {
   isShowAll.value = true;
 };
 </script>
+
+<style scoped>
+.dropdown.dropdown-center > .dropdown-content {
+  left: 50%;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -ms-transform: translateX(-50%);
+}
+</style>

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -80,4 +80,8 @@ const selectReaction = (reaction: string) => {
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
 }
+
+.dropdown.dropdown-hover:hover > .dropdown-content {
+  opacity: 0.9;
+}
 </style>

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -19,9 +19,15 @@
         {{ reaction.count }}
       </button>
       <span
-        class="dropdown-content pointer-events-none card p-1 bg-neutral text-sm z-10"
+        v-if="reaction.key.startsWith(':')"
+        class="dropdown-content pointer-events-none flex flex-col items-center bg-neutral p-2 rounded-lg z-10"
       >
-        {{ reaction.key.replace('@.', '') }}
+        <span class="h-10">
+          <MisskeyEmoji :emoji="reaction.key" :base-url="baseUrl" />
+        </span>
+        <span class="text-sm">
+          {{ reaction.key.replace('@.', '') }}
+        </span>
       </span>
     </li>
     <li v-if="reactions.length > REACTIONS_LIMIT && !isShowAll">

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -3,7 +3,7 @@
     <li
       v-for="reaction in shownReactions"
       :key="reaction.key"
-      class="dropdown dropdown-center dropdown-hover"
+      class="dropdown dropdown-top dropdown-center dropdown-hover"
     >
       <button
         class="btn btn-xs no-animation py-0.5 gap-x-1"

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -9,7 +9,7 @@
         class="btn btn-xs no-animation py-0.5 gap-x-1"
         tabindex="-1"
         :class="[reaction.key === myReaction ? 'btn-accent' : 'btn-neutral']"
-        @click="$emit('select', reaction.key, reaction.key !== myReaction)"
+        @click="selectReaction(reaction.key)"
       >
         <MisskeyEmoji
           :emoji="reaction.key"
@@ -51,7 +51,7 @@ const props = defineProps<{
   baseUrl: IMisskeyMessage['via']['instance']['baseUrl'];
 }>();
 
-defineEmits<{
+const emits = defineEmits<{
   (e: 'select', reaction: string, isCreate: boolean): void;
 }>();
 
@@ -64,6 +64,12 @@ const shownReactions = computed(() =>
 
 const showMore = () => {
   isShowAll.value = true;
+};
+
+const selectReaction = (reaction: string) => {
+  emits('select', reaction, reaction !== props.myReaction);
+  // クリック後にdropdownを非表示にするためblur
+  (document.activeElement as HTMLElement | null)?.blur();
 };
 </script>
 

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -22,7 +22,7 @@
         v-if="reaction.key.startsWith(':')"
         class="dropdown-content pointer-events-none flex flex-col items-center bg-neutral p-2 rounded-lg z-10"
       >
-        <span class="h-10">
+        <span class="h-8 w-max">
           <MisskeyEmoji :emoji="reaction.key" :base-url="baseUrl" />
         </span>
         <span class="text-sm">


### PR DESCRIPTION
- daisyuiのdropdownで実装
- 位置を上に修正
- リアクションの画像を拡大表示
- 10%透過
- クリック後に表示され続けるのでblur
  - (メモ) focus時の表示を消す方がいいかも