### PR TITLE
メッセージの公開範囲設定を追加

### DIFF
--- a/components/common/parts/Details.vue
+++ b/components/common/parts/Details.vue
@@ -1,0 +1,31 @@
+<template>
+  <details ref="details" @focusout="focusout">
+    <slot />
+  </details>
+</template>
+
+<script setup lang="ts">
+const details = ref<HTMLDetailsElement>();
+
+// descendantがancestor以下のツリーに含まれるかを判定
+const isDescendant = (
+  ancestor: HTMLElement,
+  descendant: HTMLElement,
+): boolean =>
+  ancestor === descendant ||
+  (descendant.parentElement &&
+    isDescendant(ancestor, descendant.parentElement)) ||
+  false;
+
+// focusoutした際に、選択先がdetails以下でなければdetailsを閉じる
+const focusout = (e: FocusEvent) => {
+  const relatedTarget = e.relatedTarget as HTMLElement | null;
+
+  if (!details.value) {
+    return;
+  }
+  if (!relatedTarget || !isDescendant(details.value, relatedTarget)) {
+    details.value.open = false;
+  }
+};
+</script>

--- a/components/instances/ComposeVisibility.vue
+++ b/components/instances/ComposeVisibility.vue
@@ -1,5 +1,5 @@
 <template>
-  <details class="dropdown">
+  <CommonPartsDetails class="dropdown">
     <summary class="btn mb-1">
       <span class="material-symbols-outlined">
         {{ visibilityIcons[visibility as VisibilityType] }}
@@ -7,7 +7,7 @@
     </summary>
     <ul class="dropdown-content menu z-[1] bg-base-100 rounded-box">
       <li v-for="(_, key) in visibilityIcons" :key="key">
-        <button type="button" @click="$emit('select', key as VisibilityType)">
+        <button type="button" @click="select(key as VisibilityType)">
           <span class="material-symbols-outlined">
             {{ visibilityIcons[key] }}
           </span>
@@ -15,7 +15,7 @@
         </button>
       </li>
     </ul>
-  </details>
+  </CommonPartsDetails>
 </template>
 
 <!-- TODO: なぜかgenericの型推論がtemplate内でおかしくなるため、いろいろ仮対応 -->
@@ -25,7 +25,12 @@ defineProps<{
   visibilityIcons: { [key: string]: string };
 }>();
 
-defineEmits<{
+const emits = defineEmits<{
   (e: 'select', value: VisibilityType): void;
 }>();
+
+const select = (key: VisibilityType) => {
+  emits('select', key);
+  (document.activeElement as HTMLElement | null)?.blur();
+};
 </script>

--- a/components/instances/ComposeVisibility.vue
+++ b/components/instances/ComposeVisibility.vue
@@ -1,0 +1,31 @@
+<template>
+  <details class="dropdown">
+    <summary class="btn mb-1">
+      <span class="material-symbols-outlined">
+        {{ visibilityIcons[visibility as VisibilityType] }}
+      </span>
+    </summary>
+    <ul class="dropdown-content menu z-[1] bg-base-100 rounded-box">
+      <li v-for="(_, key) in visibilityIcons" :key="key">
+        <button type="button" @click="$emit('select', key as VisibilityType)">
+          <span class="material-symbols-outlined">
+            {{ visibilityIcons[key] }}
+          </span>
+          {{ key }}
+        </button>
+      </li>
+    </ul>
+  </details>
+</template>
+
+<!-- TODO: なぜかgenericの型推論がtemplate内でおかしくなるため、いろいろ仮対応 -->
+<script setup lang="ts" generic="VisibilityType extends string">
+defineProps<{
+  visibility: VisibilityType;
+  visibilityIcons: { [key: string]: string };
+}>();
+
+defineEmits<{
+  (e: 'select', value: VisibilityType): void;
+}>();
+</script>

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -40,7 +40,6 @@ const visibilityIcons = {
 
 const selectVisibility = (value: Mastodon.v1.StatusVisibility) => {
   visibility.value = value;
-  (document.activeElement as HTMLElement | null)?.blur();
 };
 
 const submitting = ref<boolean>(false);

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -12,9 +12,16 @@
   >
     submit
   </button>
+
+  <ComposeVisibility
+    :visibility="visibility"
+    :visibility-icons="visibilityIcons"
+    @select="selectVisibility"
+  />
 </template>
 
 <script setup lang="ts">
+import type { mastodon as Mastodon } from 'masto';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
@@ -22,6 +29,20 @@ const props = defineProps<{
 }>();
 
 const message = ref<string>('');
+const visibility = ref<Mastodon.v1.StatusVisibility>('private'); // TODO: preferences
+
+const visibilityIcons = {
+  public: 'public',
+  unlisted: 'lock_open_right',
+  private: 'lock',
+  direct: 'alternate_email',
+} as const satisfies Record<Mastodon.v1.StatusVisibility, string>;
+
+const selectVisibility = (value: Mastodon.v1.StatusVisibility) => {
+  visibility.value = value;
+  (document.activeElement as HTMLElement | null)?.blur();
+};
+
 const submitting = ref<boolean>(false);
 
 const submit = async () => {
@@ -34,7 +55,7 @@ const submit = async () => {
       .get<'mastodon'>(props.user)
       .api.v1.statuses.create({
         status: message.value,
-        visibility: 'private',
+        visibility: visibility.value,
       });
 
     message.value = '';

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -30,12 +30,12 @@ const submit = async () => {
   submitting.value = true;
 
   try {
-    await (
-      await useApiClientsStore().get<'mastodon'>(props.user)
-    ).api.v1.statuses.create({
-      status: message.value,
-      visibility: 'private',
-    });
+    await useApiClientsStore()
+      .get<'mastodon'>(props.user)
+      .api.v1.statuses.create({
+        status: message.value,
+        visibility: 'private',
+      });
 
     message.value = '';
   } catch (_) {}

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -40,7 +40,6 @@ const visibilityIcons = {
 
 const selectVisibility = (value: Misskey.entities.Note['visibility']) => {
   visibility.value = value;
-  (document.activeElement as HTMLElement | null)?.blur();
 };
 
 const submitting = ref<boolean>(false);

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -30,12 +30,12 @@ const submit = async () => {
   submitting.value = true;
 
   try {
-    await (
-      await useApiClientsStore().get<'misskey'>(props.user)
-    ).api.request('notes/create', {
-      text: message.value,
-      visibility: 'followers',
-    });
+    await useApiClientsStore()
+      .get<'misskey'>(props.user)
+      .api.request('notes/create', {
+        text: message.value,
+        visibility: 'followers',
+      });
 
     message.value = '';
   } catch (_) {}

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -12,9 +12,16 @@
   >
     submit
   </button>
+
+  <ComposeVisibility
+    :visibility="visibility"
+    :visibility-icons="visibilityIcons"
+    @select="selectVisibility"
+  />
 </template>
 
 <script setup lang="ts">
+import type * as Misskey from 'misskey-js';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
@@ -22,6 +29,20 @@ const props = defineProps<{
 }>();
 
 const message = ref<string>('');
+const visibility = ref<Misskey.entities.Note['visibility']>('followers'); // TODO: preference
+
+const visibilityIcons = {
+  public: 'public',
+  home: 'home',
+  followers: 'lock',
+  specified: 'alternate_email',
+} as const satisfies Record<Misskey.entities.Note['visibility'], string>;
+
+const selectVisibility = (value: Misskey.entities.Note['visibility']) => {
+  visibility.value = value;
+  (document.activeElement as HTMLElement | null)?.blur();
+};
+
 const submitting = ref<boolean>(false);
 
 const submit = async () => {
@@ -34,7 +55,7 @@ const submit = async () => {
       .get<'misskey'>(props.user)
       .api.request('notes/create', {
         text: message.value,
-        visibility: 'followers',
+        visibility: visibility.value,
       });
 
     message.value = '';


### PR DESCRIPTION
メッセージの公開範囲を指定できるようにしました

- awaitの重複を削除
- 範囲外のクリックで閉じられるdropdownに使えるよう、Detailsコンポーネントを作成