### PR TITLE
detailsまわりの修正

### DIFF
--- a/components/common/Column/Menu.vue
+++ b/components/common/Column/Menu.vue
@@ -5,7 +5,7 @@
         <span class="material-symbols-outlined text-base">add</span>
       </summary>
       <div
-        class="menu dropdown-content bg-base-300 rounded-box border border-primary w-80"
+        class="menu dropdown-content bg-base-300 rounded-box border border-primary w-80 mr-1"
       >
         <div class="w-full">
           <label class="label">
@@ -73,3 +73,12 @@ const addTimeline = () => {
   (document.activeElement as HTMLElement | null)?.blur();
 };
 </script>
+
+<style scoped>
+.dropdown > .dropdown-content {
+  top: 50%;
+  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+}
+</style>

--- a/components/common/parts/Details.vue
+++ b/components/common/parts/Details.vue
@@ -1,5 +1,10 @@
 <template>
-  <details ref="details" @focusout="focusout">
+  <details
+    ref="details"
+    tabindex="-1"
+    class="w-fit bg-red"
+    @focusout="focusout"
+  >
     <slot />
   </details>
 </template>
@@ -18,6 +23,7 @@ const isDescendant = (
   false;
 
 // focusoutした際に、選択先がdetails以下でなければdetailsを閉じる
+// tabindex="-1" でdetails内ならrelatedTargetが常に設定されるはず
 const focusout = (e: FocusEvent) => {
   const relatedTarget = e.relatedTarget as HTMLElement | null;
 

--- a/components/instances/ComposeVisibility.vue
+++ b/components/instances/ComposeVisibility.vue
@@ -7,7 +7,11 @@
     </summary>
     <ul class="dropdown-content menu z-[1] bg-base-100 rounded-box">
       <li v-for="(_, key) in visibilityIcons" :key="key">
-        <button type="button" @click="select(key as VisibilityType)">
+        <button
+          type="button"
+          :class="{ 'text-warning': key === visibility }"
+          @click="select(key as VisibilityType)"
+        >
           <span class="material-symbols-outlined">
             {{ visibilityIcons[key] }}
           </span>

--- a/components/instances/misskey/ColumnItem.vue
+++ b/components/instances/misskey/ColumnItem.vue
@@ -40,7 +40,7 @@
           <span class="material-symbols-outlined text-base">reply</span>
         </button>
         <CommonPartsDetails
-          class="dropdown dropdown-hover"
+          class="dropdown"
           :class="{ 'dropdown-top': isLast }"
         >
           <summary


### PR DESCRIPTION
- CommonPartsDetailsで、内部をクリックしているのにrelatedFocusがnullになるのを修正
- ColumnMenuのコンテンツが高さ中央に出るように修正
- Misskeyのrenoteはクリックで表示するようにしたので、classからhoverを削除
- visibilityで選択中のものは色を付けて強調表示するように