### PR TITLE
Misskeyのリアクション表示修正・不明なloginUserを無視

### DIFF
--- a/components/common/Timeline/index.vue
+++ b/components/common/Timeline/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section>
+  <section v-if="user">
     <CommonPartsContainer
       class="h-full w-[330px] bg-base-100"
       @top="atTop"

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -8,7 +8,11 @@
       <button
         class="btn btn-xs no-animation py-0.5 gap-x-1"
         tabindex="-1"
-        :class="[reaction.key === myReaction ? 'btn-accent' : 'btn-neutral']"
+        :class="[
+          reaction.key === myReaction
+            ? 'btn-outline btn-success'
+            : 'btn-neutral',
+        ]"
         @click="selectReaction(reaction.key)"
       >
         <MisskeyMFMEmoji :emoji="reaction.key" :base-url="baseUrl" />
@@ -28,7 +32,7 @@
     </li>
     <li v-if="reactions.length > REACTIONS_LIMIT && !isShowAll">
       <button
-        class="btn btn-xs btn-accent btn-outline no-animation"
+        class="btn btn-xs btn-outline no-animation"
         tabindex="-1"
         @click="showMore"
       >

--- a/stores/loginUsersStore.ts
+++ b/stores/loginUsersStore.ts
@@ -28,11 +28,17 @@ export const useLoginUsersStore = defineStore('loginUsers', () => {
   // orderedLoginUsers は型としては配列だが、読み込み中はundefinedになるので、pageレベルでv-ifすること
   const orderedLoginUsers = computedAsync<ILoginUser[]>(async () => {
     const { $repositories } = useNuxtApp();
-    return await Promise.all(
+    const users = await Promise.all(
       storage.value.map(async (user) => {
-        return await $repositories(user.instance.type).getLoginUser(user);
+        try {
+          return await $repositories(user.instance.type).getLoginUser(user);
+        } catch {
+          return undefined;
+        }
       }),
     );
+
+    return users.filter((user) => !!user) as ILoginUser[];
   }, undefined);
 
   const loginUsers = computed(() => {


### PR DESCRIPTION
- Misskeyのリアクションで選択したものをborder表示にするように修正
- 不明なloginUserを無視
  - loginUser情報を取れなかった場合、非表示にする
  - セッションが切れた場合などは、アカウント管理画面を作成したときに考える