### PR TITLE
スクロールバーのデザインを修正

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -11,9 +11,12 @@
   border-radius: 2px;
 }
 
-* {
-  scrollbar-width: thin;
-  scrollbar-color: oklch(var(--p)) transparent;
+@-moz-document url-prefix() {
+  /* firefox only */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: oklch(var(--p)) transparent;
+  } 
 }
 
 .textarea {


### PR DESCRIPTION
Chrome 121で `scrollbar-width` に対応したため、デザインが崩れてしまったのを修正

firefoxでのみ `scrollbar-width` を使い、そのほかでは引き続き `::-webkit-scrollbar` で設定する