### PR TITLE
細かい修正・Safariでの表示修正

### DIFF
--- a/components/common/Modal/Media.vue
+++ b/components/common/Modal/Media.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="modalMedia"
-    class="modal-size flex flex-col justify-center outline-none relative"
+    class="modal-size outline-none relative"
     tabindex="0"
     @keydown.right="goNext"
     @keydown.left="goPrev"
@@ -18,11 +18,9 @@
     </video>
     <img
       v-if="current.type === 'image'"
-      :key="key"
       :src="current.url"
-      class="media-size"
+      class="media-size inline-block"
       draggable="false"
-      @load="onload"
     />
     <audio
       v-if="current.type === 'audio'"
@@ -61,20 +59,12 @@ const modalMedia = ref<HTMLElement>();
 const index = ref(props.initial);
 const current = computed(() => props.mediaList[index.value]);
 
-// Safariでは画像のロード後に自動リサイズされないので、keyで再描画する
-const key = ref(0);
-const onload = () => {
-  key.value = 1;
-};
-
 const goNext = () => {
   index.value = (index.value + 1) % props.mediaList.length;
-  key.value = 0;
 };
 const goPrev = () => {
   index.value =
     (props.mediaList.length + index.value - 1) % props.mediaList.length;
-  key.value = 0;
 };
 
 onMounted(() => {

--- a/components/common/Sidebar.vue
+++ b/components/common/Sidebar.vue
@@ -22,7 +22,7 @@
               <span class="material-symbols-outlined">settings</span>
             </summary>
             <ul
-              class="menu dropdown-content bg-base-100 rounded-box w-48 z-[10]"
+              class="menu dropdown-content bg-base-100 rounded-box w-max z-[10]"
             >
               <li>
                 <button type="button" @click="openLogin">

--- a/components/common/Timeline/Item/Container.vue
+++ b/components/common/Timeline/Item/Container.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="flex gap-x-2 p-2 pt-3">
+  <article class="flex gap-x-2 mx-2 py-2">
     <div class="flex-none">
       <a href="#" tabindex="-1">
         <CommonPartsRoundedIcon :icon-url="user.iconUrl" class="w-9 h-9" />

--- a/components/common/Timeline/index.vue
+++ b/components/common/Timeline/index.vue
@@ -128,8 +128,7 @@ const loadPast = async () => {
         (items.value[0] as IBlueskyMessage)?.cursor ?? items.value[0]?.id,
     });
 
-    items.value.reverse().push(...messages);
-    items.value.reverse();
+    items.value.unshift(...messages.reverse());
 
     // レスポンスがなければ無限スクロールを終了
     if (messages.length === 0) {

--- a/components/common/Timeline/index.vue
+++ b/components/common/Timeline/index.vue
@@ -20,11 +20,11 @@
 
             <button
               type="button"
-              class="btn btn-ghost btn-square btn-sm w-fit"
+              class="btn btn-ghost btn-square btn-xs"
               tabindex="-1"
               @click.stop="toggleDetail"
             >
-              <span class="material-symbols-outlined text-lg">
+              <span class="material-symbols-outlined">
                 {{ isDetailExpanded ? 'expand_less' : 'expand_more' }}
               </span>
             </button>

--- a/components/instances/misskey/ColumnItemReactions.vue
+++ b/components/instances/misskey/ColumnItemReactions.vue
@@ -6,7 +6,7 @@
       class="dropdown dropdown-top dropdown-center dropdown-hover"
     >
       <button
-        class="btn btn-xs no-animation py-0.5 gap-x-1"
+        class="btn btn-xs no-animation flex-nowrap py-0.5 gap-x-1"
         tabindex="-1"
         :class="[
           reaction.key === myReaction

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,10 +1,8 @@
 <template>
   <div>
     <template v-if="orderedLoginUsers?.length">
-      <div
-        class="flex gap-1 h-screen w-screen bg-base-300 max-sm:flex-col-reverse"
-      >
-        <CommonSidebar />
+      <div class="flex gap-1 h-screen w-screen bg-base-300 max-sm:flex-col">
+        <CommonSidebar class="max-sm:order-last" />
         <div class="flex-auto flex gap-x-1 overflow-x-auto">
           <CommonTimeline
             v-for="timeline in timelines"


### PR DESCRIPTION
- `TimelineItemContainer` のSpacing指定を修正
- flex指定を修正
- 要素追加時に `unshift` を使うように修正
- `TimelineConfig` のボタン指定を修正
- Sidebarのメニューの幅指定を修正
- Safariの表示修正
  - media modalのflexを削除
  - misskeyのリアクション表示にflex-nowrapを追加