### PR TITLE
dayjsを直接使う形に変更・相対時刻の丸めを抑制

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,6 @@ export default defineNuxtConfig({
     '@nuxtjs/tailwindcss',
     '@vueuse/nuxt',
     '@pinia/nuxt',
-    'dayjs-nuxt',
     '@vite-pwa/nuxt',
   ],
   components: [{ path: '~/components/instances', prefix: '' }, '~/components'],
@@ -43,28 +42,5 @@ export default defineNuxtConfig({
       theme_color: 'black',
       icons: [],
     },
-  },
-  dayjs: {
-    plugins: ['relativeTime'],
-    defaultLocale: [
-      'en',
-      {
-        relativeTime: {
-          future: '-%s',
-          past: '%s',
-          s: '%ds',
-          m: '1m',
-          mm: '%dm',
-          h: '1h',
-          hh: '%dh',
-          d: '1d',
-          dd: '%dd',
-          M: '1mo',
-          MM: '%dmo',
-          y: '1y',
-          yy: '%dy',
-        },
-      },
-    ],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@atproto/api": "^0.11.0",
         "@pinia/nuxt": "^0.5.1",
+        "dayjs": "^1.11.10",
         "masto": "^6.0.5",
         "mfm-js": "^0.24.0",
         "misskey-js": "^2024.3.1",
@@ -27,7 +28,6 @@
         "@vueuse/core": "^10.3.0",
         "@vueuse/nuxt": "^10.3.0",
         "daisyui": "^4.4.19",
-        "dayjs-nuxt": "^2.1.9",
         "eslint": "^8.44.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.1",
@@ -7516,18 +7516,7 @@
     "node_modules/dayjs": {
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "dev": true
-    },
-    "node_modules/dayjs-nuxt": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/dayjs-nuxt/-/dayjs-nuxt-2.1.9.tgz",
-      "integrity": "sha512-7L1X8Wm+O2s2o+YK8RH1GK0SUUsh7l0lnIzsjaLGvyu64asLs2KVNoh25J4tQurdILp2TyrFaTo/k3k/ZPub9Q==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/kit": "^3.7.4",
-        "dayjs": "^1.11.10"
-      }
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/db0": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@atproto/api": "^0.11.0",
     "@pinia/nuxt": "^0.5.1",
+    "dayjs": "^1.11.10",
     "masto": "^6.0.5",
     "mfm-js": "^0.24.0",
     "misskey-js": "^2024.3.1",
@@ -36,7 +37,6 @@
     "@vueuse/core": "^10.3.0",
     "@vueuse/nuxt": "^10.3.0",
     "daisyui": "^4.4.19",
-    "dayjs-nuxt": "^2.1.9",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",

--- a/plugins/dayjs.ts
+++ b/plugins/dayjs.ts
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import updateLocale from 'dayjs/plugin/updateLocale';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+export default defineNuxtPlugin((_nuxtApp) => {
+  dayjs.extend(relativeTime);
+  dayjs.extend(updateLocale);
+  dayjs.updateLocale('en', {
+    relativeTime: {
+      future: '-%s',
+      past: '%s',
+      s: '%ds',
+      m: '1m',
+      mm: '%dm',
+      h: '1h',
+      hh: '%dh',
+      d: '1d',
+      dd: '%dd',
+      M: '1mo',
+      MM: '%dmo',
+      y: '1y',
+      yy: '%dy',
+    },
+  });
+
+  return {
+    provide: {
+      dayjs,
+    },
+  };
+});

--- a/plugins/dayjs.ts
+++ b/plugins/dayjs.ts
@@ -3,7 +3,22 @@ import updateLocale from 'dayjs/plugin/updateLocale';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 export default defineNuxtPlugin((_nuxtApp) => {
-  dayjs.extend(relativeTime);
+  dayjs.extend(relativeTime, {
+    thresholds: [
+      { l: 's', r: 59, d: 'second' },
+      { l: 'm', r: 1 },
+      { l: 'mm', r: 59, d: 'minute' },
+      { l: 'h', r: 1 },
+      { l: 'hh', r: 23, d: 'hour' },
+      { l: 'd', r: 1 },
+      { l: 'dd', r: 29, d: 'day' },
+      { l: 'M', r: 1 },
+      { l: 'MM', r: 11, d: 'month' },
+      { l: 'y' },
+      { l: 'yy', d: 'year' },
+    ],
+  });
+
   dayjs.extend(updateLocale);
   dayjs.updateLocale('en', {
     relativeTime: {

--- a/utils/calcRelativeTime.ts
+++ b/utils/calcRelativeTime.ts
@@ -1,4 +1,4 @@
 export const calcRelativeTime = (date: Date, from: Date = new Date()) => {
-  const dayjs = useDayjs();
-  return dayjs(date).from(from);
+  const { $dayjs } = useNuxtApp();
+  return $dayjs(date).from(from);
 };


### PR DESCRIPTION
- `dayjs-nuxt` をやめ `dayjs` を直接使う形に変更
  - 下記修正が `dayjs-nuxt` を使いながらできなかったため
- 相対時刻が丸めて表示されていた(`45s` -> `1m`)のを抑制