### PR TITLE
useComposeを追加

### DIFF
--- a/components/common/Sidebar/Compose.vue
+++ b/components/common/Sidebar/Compose.vue
@@ -1,0 +1,39 @@
+<template>
+  <section
+    v-if="activeComposeUser"
+    v-show="config.sidebar.isExpanded"
+    class="flex flex-col gap-y-3 w-64 p-2 bg-neutral max-sm:h-64 max-sm:w-full"
+  >
+    <CommonPartsUserSelector
+      v-model="activeComposeUser"
+      :users="orderedLoginUsers"
+    />
+
+    <KeepAlive>
+      <component
+        :is="composeComponents[activeComposeUser.instance.type]"
+        :user="activeComposeUser"
+      />
+    </KeepAlive>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  BlueskySidebarCompose,
+  MastodonSidebarCompose,
+  MisskeySidebarCompose,
+} from '#components';
+import type { ILoginUser } from '~/models/common/user';
+
+const composeComponents = {
+  bluesky: BlueskySidebarCompose,
+  mastodon: MastodonSidebarCompose,
+  misskey: MisskeySidebarCompose,
+};
+
+const { config } = storeToRefs(useConfigStore());
+const { orderedLoginUsers } = storeToRefs(useLoginUsersStore());
+
+const activeComposeUser = ref<ILoginUser>(orderedLoginUsers.value[0]);
+</script>

--- a/components/common/Sidebar/ComposeTextarea.vue
+++ b/components/common/Sidebar/ComposeTextarea.vue
@@ -1,5 +1,6 @@
 <template>
   <textarea
+    ref="textareaRef"
     v-model="model"
     :readonly="readonly"
     class="textarea w-full h-96"
@@ -19,8 +20,14 @@ const emits = defineEmits<{
   (e: 'submit'): void;
 }>();
 
+const textareaRef = ref<HTMLTextAreaElement>();
+
 const handleKeydownEnter = (e: KeyboardEvent) => {
   if (!e.ctrlKey && !e.metaKey) return;
   emits('submit');
 };
+
+defineExpose({
+  focus: () => textareaRef.value?.focus(),
+});
 </script>

--- a/components/common/Sidebar/ComposeTextarea.vue
+++ b/components/common/Sidebar/ComposeTextarea.vue
@@ -1,35 +1,26 @@
 <template>
   <textarea
-    :value="modelValue"
+    v-model="model"
     :readonly="readonly"
     class="textarea w-full h-96"
-    @input="onInput"
     @keydown.enter.meta.exact="handleKeydownEnter"
-    @keydown.s.meta.exact="handleKeydownS"
+    @keydown.s.meta.exact.prevent
   />
 </template>
 
 <script setup lang="ts">
+const model = defineModel<string>();
+
 defineProps<{
-  modelValue: string;
   readonly: boolean;
 }>();
 
 const emits = defineEmits<{
-  (e: 'update:modelValue', value: string): void;
   (e: 'submit'): void;
 }>();
-
-const onInput = (event: Event) => {
-  emits('update:modelValue', (event.target as HTMLTextAreaElement).value);
-};
 
 const handleKeydownEnter = (e: KeyboardEvent) => {
   if (!e.ctrlKey && !e.metaKey) return;
   emits('submit');
-};
-
-const handleKeydownS = (e: KeyboardEvent) => {
-  e.preventDefault();
 };
 </script>

--- a/components/common/Sidebar/index.vue
+++ b/components/common/Sidebar/index.vue
@@ -40,51 +40,25 @@
             </ul>
           </CommonPartsDetails>
         </div>
+
+        <CommonModalLogin
+          v-if="isOpenLoginModal"
+          @close="isOpenLoginModal = false"
+        />
+        <CommonModalConfig
+          v-if="isOpenSettingsModal"
+          @close="isOpenSettingsModal = false"
+        />
       </template>
     </CommonPartsContainer>
 
-    <section
-      v-if="activeLoginUser"
-      v-show="config.sidebar.isExpanded"
-      class="flex flex-col gap-y-3 w-64 p-2 bg-neutral max-sm:h-64 max-sm:w-full"
-    >
-      <CommonPartsUserSelector
-        v-model="activeLoginUser"
-        :users="orderedLoginUsers"
-      />
-
-      <KeepAlive>
-        <component
-          :is="composeComponents[activeLoginUser.instance.type]"
-          :user="activeLoginUser"
-        />
-      </KeepAlive>
-    </section>
-
-    <CommonModalLogin
-      v-if="isOpenLoginModal"
-      @close="isOpenLoginModal = false"
-    />
-    <CommonModalConfig
-      v-if="isOpenSettingsModal"
-      @close="isOpenSettingsModal = false"
-    />
+    <!-- 入力画面の開閉状態はコンポーネント側で行う -->
+    <CommonSidebarCompose />
   </header>
 </template>
 
 <script setup lang="ts">
-import type { ILoginUser } from '~/models/common/user';
-
-const composeComponents = {
-  bluesky: resolveComponent('BlueskySidebarCompose'),
-  mastodon: resolveComponent('MastodonSidebarCompose'),
-  misskey: resolveComponent('MisskeySidebarCompose'),
-};
-
-const { orderedLoginUsers } = storeToRefs(useLoginUsersStore());
-
 const { config } = storeToRefs(useConfigStore());
-const activeLoginUser = ref<ILoginUser>(orderedLoginUsers.value[0]);
 
 const isOpenLoginModal = ref(false);
 const isOpenSettingsModal = ref(false);

--- a/components/instances/bluesky/SidebarCompose.vue
+++ b/components/instances/bluesky/SidebarCompose.vue
@@ -1,6 +1,6 @@
 <template>
   <CommonSidebarComposeTextarea
-    v-model="message"
+    ref="textareaRef"
     :readonly="submitting"
     @submit="submit"
   />
@@ -18,14 +18,16 @@
 </template>
 
 <script setup lang="ts">
+import { CommonSidebarComposeTextarea } from '#components';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
   user: ILoginUser;
 }>();
 
-const message = ref<string>('');
+const textareaRef = ref<InstanceType<typeof CommonSidebarComposeTextarea>>();
 
+const message = ref<string>('');
 const submitting = ref<boolean>(false);
 
 const submit = async () => {
@@ -43,4 +45,7 @@ const submit = async () => {
 
   submitting.value = false;
 };
+
+const focus = () => textareaRef.value?.focus();
+onActivated(focus);
 </script>

--- a/components/instances/bluesky/SidebarCompose.vue
+++ b/components/instances/bluesky/SidebarCompose.vue
@@ -1,5 +1,5 @@
 <template>
-  <CommonPartsTextarea
+  <CommonSidebarComposeTextarea
     v-model="message"
     :readonly="submitting"
     @submit="submit"

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -1,6 +1,7 @@
 <template>
   <CommonSidebarComposeTextarea
     ref="textareaRef"
+    v-model="message.text"
     :readonly="submitting"
     @submit="submit"
   />
@@ -15,7 +16,7 @@
     <button
       type="button"
       class="btn btn-primary btn-circle ml-auto"
-      :disabled="submitting || message.length === 0"
+      :disabled="!isSubmitable"
       @click="submit"
     >
       <span class="material-symbols-outlined">arrow_forward</span>
@@ -26,6 +27,7 @@
 <script setup lang="ts">
 import { CommonSidebarComposeTextarea } from '#components';
 import type { mastodon as Mastodon } from 'masto';
+import type { IComposeMessage } from '~/models/common/composeMessage';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
@@ -34,9 +36,42 @@ const props = defineProps<{
 
 const textareaRef = ref<InstanceType<typeof CommonSidebarComposeTextarea>>();
 
-const message = ref<string>('');
-const visibility = ref<Mastodon.v1.StatusVisibility>('private'); // TODO: preferences
+const message = ref<IComposeMessage>({});
+const submitting = ref<boolean>(false);
 
+const isSubmitable = computed(() => !submitting.value && message.value.text);
+
+const submit = async () => {
+  if (!isSubmitable.value) return;
+
+  submitting.value = true;
+
+  try {
+    await useApiClientsStore()
+      .get<'mastodon'>(props.user)
+      .api.v1.statuses.create({
+        status: message.value.text!,
+        visibility: visibility.value,
+      });
+
+    message.value = {};
+  } catch (_) {}
+
+  submitting.value = false;
+};
+
+const focus = () => textareaRef.value?.focus();
+onActivated(focus);
+
+defineExpose({
+  focus,
+  setMessage: (data: IComposeMessage) => {
+    message.value = data;
+  },
+});
+
+// visibility
+const visibility = ref<Mastodon.v1.StatusVisibility>('private'); // TODO: preferences
 const visibilityIcons = {
   public: 'public',
   unlisted: 'lock_open_right',
@@ -47,28 +82,4 @@ const visibilityIcons = {
 const selectVisibility = (value: Mastodon.v1.StatusVisibility) => {
   visibility.value = value;
 };
-
-const submitting = ref<boolean>(false);
-
-const submit = async () => {
-  if (message.value.length === 0 || submitting.value) return;
-
-  submitting.value = true;
-
-  try {
-    await useApiClientsStore()
-      .get<'mastodon'>(props.user)
-      .api.v1.statuses.create({
-        status: message.value,
-        visibility: visibility.value,
-      });
-
-    message.value = '';
-  } catch (_) {}
-
-  submitting.value = false;
-};
-
-const focus = () => textareaRef.value?.focus();
-onActivated(focus);
 </script>

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -1,5 +1,5 @@
 <template>
-  <CommonPartsTextarea
+  <CommonSidebarComposeTextarea
     v-model="message"
     :readonly="submitting"
     @submit="submit"

--- a/components/instances/mastodon/SidebarCompose.vue
+++ b/components/instances/mastodon/SidebarCompose.vue
@@ -1,6 +1,6 @@
 <template>
   <CommonSidebarComposeTextarea
-    v-model="message"
+    ref="textareaRef"
     :readonly="submitting"
     @submit="submit"
   />
@@ -24,12 +24,15 @@
 </template>
 
 <script setup lang="ts">
+import { CommonSidebarComposeTextarea } from '#components';
 import type { mastodon as Mastodon } from 'masto';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
   user: ILoginUser;
 }>();
+
+const textareaRef = ref<InstanceType<typeof CommonSidebarComposeTextarea>>();
 
 const message = ref<string>('');
 const visibility = ref<Mastodon.v1.StatusVisibility>('private'); // TODO: preferences
@@ -65,4 +68,7 @@ const submit = async () => {
 
   submitting.value = false;
 };
+
+const focus = () => textareaRef.value?.focus();
+onActivated(focus);
 </script>

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -1,6 +1,7 @@
 <template>
   <CommonSidebarComposeTextarea
     ref="textareaRef"
+    v-model="message.text"
     :readonly="submitting"
     @submit="submit"
   />
@@ -15,7 +16,7 @@
     <button
       type="button"
       class="btn btn-primary btn-circle ml-auto"
-      :disabled="submitting || message.length === 0"
+      :disabled="!isSubmitable"
       @click="submit"
     >
       <span class="material-symbols-outlined">arrow_forward</span>
@@ -26,6 +27,7 @@
 <script setup lang="ts">
 import { CommonSidebarComposeTextarea } from '#components';
 import type * as Misskey from 'misskey-js';
+import type { IComposeMessage } from '~/models/common/composeMessage';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
@@ -34,9 +36,42 @@ const props = defineProps<{
 
 const textareaRef = ref<InstanceType<typeof CommonSidebarComposeTextarea>>();
 
-const message = ref<string>('');
-const visibility = ref<Misskey.entities.Note['visibility']>('followers'); // TODO: preference
+const message = ref<IComposeMessage>({});
+const submitting = ref<boolean>(false);
 
+const isSubmitable = computed(() => !submitting.value && message.value.text);
+
+const submit = async () => {
+  if (!isSubmitable.value) return;
+
+  submitting.value = true;
+
+  try {
+    await useApiClientsStore()
+      .get<'misskey'>(props.user)
+      .api.request('notes/create', {
+        text: message.value.text,
+        visibility: visibility.value,
+      });
+
+    message.value = {};
+  } catch (_) {}
+
+  submitting.value = false;
+};
+
+const focus = () => textareaRef.value?.focus();
+onActivated(focus);
+
+defineExpose({
+  focus,
+  setMessage: (data: IComposeMessage) => {
+    message.value = data;
+  },
+});
+
+// visibility
+const visibility = ref<Misskey.entities.Note['visibility']>('followers'); // TODO: preference
 const visibilityIcons = {
   public: 'public',
   home: 'home',
@@ -47,28 +82,4 @@ const visibilityIcons = {
 const selectVisibility = (value: Misskey.entities.Note['visibility']) => {
   visibility.value = value;
 };
-
-const submitting = ref<boolean>(false);
-
-const submit = async () => {
-  if (message.value.length === 0 || submitting.value) return;
-
-  submitting.value = true;
-
-  try {
-    await useApiClientsStore()
-      .get<'misskey'>(props.user)
-      .api.request('notes/create', {
-        text: message.value,
-        visibility: visibility.value,
-      });
-
-    message.value = '';
-  } catch (_) {}
-
-  submitting.value = false;
-};
-
-const focus = () => textareaRef.value?.focus();
-onActivated(focus);
 </script>

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -1,6 +1,6 @@
 <template>
   <CommonSidebarComposeTextarea
-    v-model="message"
+    ref="textareaRef"
     :readonly="submitting"
     @submit="submit"
   />
@@ -24,12 +24,15 @@
 </template>
 
 <script setup lang="ts">
+import { CommonSidebarComposeTextarea } from '#components';
 import type * as Misskey from 'misskey-js';
 import type { ILoginUser } from '~/models/common/user';
 
 const props = defineProps<{
   user: ILoginUser;
 }>();
+
+const textareaRef = ref<InstanceType<typeof CommonSidebarComposeTextarea>>();
 
 const message = ref<string>('');
 const visibility = ref<Misskey.entities.Note['visibility']>('followers'); // TODO: preference
@@ -65,4 +68,7 @@ const submit = async () => {
 
   submitting.value = false;
 };
+
+const focus = () => textareaRef.value?.focus();
+onActivated(focus);
 </script>

--- a/components/instances/misskey/SidebarCompose.vue
+++ b/components/instances/misskey/SidebarCompose.vue
@@ -1,5 +1,5 @@
 <template>
-  <CommonPartsTextarea
+  <CommonSidebarComposeTextarea
     v-model="message"
     :readonly="submitting"
     @submit="submit"

--- a/composables/useCompose.ts
+++ b/composables/useCompose.ts
@@ -1,0 +1,48 @@
+import type { IComposeMessage } from '~/models/common/composeMessage';
+import type { ILoginUser } from '~/models/common/user';
+
+type IComposeData = {
+  onlyFocus?: true;
+  data?: {
+    userId: ILoginUser['id'];
+    message: IComposeMessage;
+  };
+};
+
+// composeUserの切り替え・フォーカスの調整を行うためのComposable
+// Stateを持つが、一時的なものであるためStoreにはしない
+export const useCompose = () => {
+  const switchComposeData = useState<IComposeData | undefined>(
+    'switchComposeData',
+    () => undefined,
+  );
+
+  const focus = () => {
+    switchComposeData.value = {
+      ...switchComposeData.value,
+      onlyFocus: true,
+    };
+  };
+
+  const set = (userId: ILoginUser['id'], message: IComposeMessage) => {
+    if (switchComposeData.value) {
+      return;
+    }
+
+    switchComposeData.value = {
+      data: {
+        userId,
+        message,
+      },
+    };
+  };
+
+  const clear = () => (switchComposeData.value = undefined);
+
+  return {
+    switchComposeData: readonly(switchComposeData),
+    focus,
+    set,
+    clear,
+  };
+};

--- a/models/common/composeMessage.ts
+++ b/models/common/composeMessage.ts
@@ -1,0 +1,3 @@
+export type IComposeMessage = Partial<{
+  text: string;
+}>;

--- a/types/ValueOf.ts
+++ b/types/ValueOf.ts
@@ -1,0 +1,1 @@
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
リプライや引用をCompose外から指定できるようにするため、useComposeを追加しました

useCompose自体はメッセージを一時的に持つだけにし、そのメッセージに変化があれば、各Composeコンポーネントに渡してデータを上書きするような動作にしています
メッセージ自体の管理をuseComposeにさせるのは、データの配分やインスタンス独自機能の考慮が大変になるので今回は採用せず、今後再検討することにします